### PR TITLE
Support multiple ips

### DIFF
--- a/ansible/libvirt-vm-single.yml
+++ b/ansible/libvirt-vm-single.yml
@@ -28,9 +28,9 @@
 
 - name: Ensure configdrive is decoded and decompressed
   shell: >
-      base64 -d {{ image_cache_path }}/{{ vm_host | to_uuid }}.gz
-      | gunzip
-      > {{ vm_configdrive_path }}
+    base64 -d {{ image_cache_path }}/{{ vm_host | to_uuid }}.gz
+    | gunzip
+    > {{ vm_configdrive_path }}
 
 - name: Ensure unnecessary files are removed
   file:
@@ -71,10 +71,9 @@
 - name: Wait for SSH access to the VM
   local_action:
     module: wait_for
-    host: "{{ hostvars[vm_host].vm_ip }}"
+    host: "{{ hostvars[vm_host].vm_configdrive_network_device_list[0].address }}"
     port: 22
     state: started
     # NOTE: Ensure we exceed the 5 minute DHCP timeout of the eth0
     # interface if necessary.
     timeout: 360
-


### PR DESCRIPTION
A more flexible approach to defining which IP to ssh-poll is to take the first element of the vm_configdrive_network_device_list. This is particularly useful where multiple interfaces are defined in the config and vm_ip might not be a useful name