### PR TITLE
Enable specification of user_data

### DIFF
--- a/ansible/group_vars/libvirt-vms
+++ b/ansible/group_vars/libvirt-vms
@@ -30,3 +30,10 @@ vm_configdrive_network_device_list:
     mtu: 1500
 
 vm_hypervisor: "{{ groups['libvirt-hosts'][0] }}"
+
+vm_user_data: |
+       #cloud-config
+       users:
+         - default
+         - name: stack
+           lock_passwd: true

--- a/ansible/group_vars/libvirt-vms
+++ b/ansible/group_vars/libvirt-vms
@@ -31,9 +31,10 @@ vm_configdrive_network_device_list:
 
 vm_hypervisor: "{{ groups['libvirt-hosts'][0] }}"
 
-vm_user_data: |
-       #cloud-config
-       users:
-         - default
-         - name: stack
-           lock_passwd: true
+# user_data can be passed to the instance
+#vm_user_data: |
+#       #cloud-config
+#       users:
+#         - default
+#         - name: stack
+#           lock_passwd: true

--- a/ansible/libvirt-vm-single.yml
+++ b/ansible/libvirt-vm-single.yml
@@ -7,6 +7,16 @@
     group: "{{ ansible_user_gid }}"
   become: True
 
+- name: If defined, create a user_data file
+  copy:
+    content: "{{ hostvars[vm_host].vm_user_data }}"
+    dest: "{{ image_cache_path ~ '/user_data' }}"
+    mode: "0600"
+    owner: "{{ ansible_user_uid }}"
+    group: "{{ ansible_user_gid }}"
+  when: hostvars[vm_host].vm_user_data is defined and hostvars[vm_host].vm_user_data
+  become: True
+
 - import_role:
     name: jriguera.configdrive
   vars:
@@ -17,6 +27,7 @@
     configdrive_name: "{{ vm_host }}"
     configdrive_ssh_public_key: "{{ lookup('file', ssh_public_key_path) }}"
     configdrive_config_dir: "{{ image_cache_path }}"
+    configdrive_config_user_data_path: "{{ (image_cache_path ~ '/user_data') if hostvars[vm_host].vm_user_data is defined | default(omit) }}"
     configdrive_instance_dir: "{{ configdrive_uuid }}"
     configdrive_volume_path: "{{ image_cache_path }}"
     configdrive_config_dir_delete: True
@@ -28,9 +39,9 @@
 
 - name: Ensure configdrive is decoded and decompressed
   shell: >
-      base64 -d {{ image_cache_path }}/{{ vm_host | to_uuid }}.gz
-      | gunzip
-      > {{ vm_configdrive_path }}
+    base64 -d {{ image_cache_path }}/{{ vm_host | to_uuid }}.gz
+    | gunzip
+    > {{ vm_configdrive_path }}
 
 - name: Ensure unnecessary files are removed
   file:
@@ -77,4 +88,3 @@
     # NOTE: Ensure we exceed the 5 minute DHCP timeout of the eth0
     # interface if necessary.
     timeout: 360
-

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,6 @@
 ---
 - src: jriguera.configdrive
   # There are no versioned releases of this role.
-  version: acd08fd126d0e442ab8b3bc518e37761390d8c2f
+  version: f9baca67ad8df980c7202c0d7b3039aba517813f
 - src: stackhpc.libvirt-host
 - src: stackhpc.libvirt-vm


### PR DESCRIPTION
Add vm_user_data to the group/ host vars to enable users of this repo to define user_data configurations on a per host basis.

This change depends on: https://github.com/jriguera/ansible-role-configdrive/pull/14